### PR TITLE
8 setup ci

### DIFF
--- a/.github/workflows/ruff-format.yml
+++ b/.github/workflows/ruff-format.yml
@@ -1,0 +1,10 @@
+name: Ruff
+on: [pull_request]
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/ruff-action@v1
+        with:
+          args: "format --check"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  # Ruff version.
+  rev: v0.7.3
+  hooks:
+    # Run the linter.
+    - id: ruff-format

--- a/README.md
+++ b/README.md
@@ -60,11 +60,26 @@ The following command installs all of the necessary dependencies for `nonlocal_g
 poetry install --no-root
 ```
 
-If plan to develop `nonlocal_gwfluxes`, please add the optional `develop` dependencies.
+>[!IMPORTANT]
+>If you plan to develop `nonlocal_gwfluxes`, please add the optional `develop` dependencies and complete the further setup actions detailed below.
 
 ```bash
 poetry install --no-root --with develop
 ```
+
+Installation of the `pre-commit` hooks is completed with the following instruction.
+
+```bash
+pre-commit install
+```
+
+The `pre-commit` hooks can be run manually at any time with the following instruction.
+
+```bash
+pre-commit run --all-files
+```
+>[!NOTE]
+>This repository enforces a consistent code style with `ruff` through `pre-commit` hooks and `github` actions. The rules `ruff` applies are detailed in the `tool.ruff.lint` section of the `pyroject.toml`.
 
 ## Usage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ optional = true
 
 [tool.poetry.group.develop.dependencies]
 ruff = "^0.7.3"
+pre-commit= "^4.0.1"
 
 [project.urls]
 homepage = "https://github.com/DataWaveProject/nonlocal_gwfluxes"


### PR DESCRIPTION
This PR closes #8.

#17 should be merged to `main` before this PR is approved.

Added:
- automatic ruff formatting on commit (run manually with `pre-commit run --all-files`)
- GitHub action to run ruff formatting again on PR

We can add further tests and checks as required.

There are multiple files with diffs here as this PR is based off @TomMelt addition of ruff as formatter. The changes from that branch haven't been merged into main yet and so they appear in the diffs here.

The important files to check are just those associated with the CI process:
- `ruff-format.yml`
- `.pre-comit-config.yaml`


I intend to squash all commits and rebase before merging into main.

### Merge order
- Merge #15 before merging this PR. 
- Merge #17 before merging this PR. 