### PR TITLE
chore: update pyproject for poetry v2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,13 @@
-[tool.poetry]
+[project]
 name = "nonlocal_gw"
 version = "0.0.1"
 description = "Datadriven models for predicting gravity wave fluxes in climate models."
-authors = ["amangupta2"]
+authors = [{ name = "amangupta2"}]
 readme = "README.md"
 license = "LICENSE"
 keywords = ["non-local", "gravity waves"]
+dynamic = [ "dependencies" ]
+requires-python = ">=3.10.0"
 
 [tool.poetry.dependencies]
 python = "^3.10.0"
@@ -24,7 +26,7 @@ optional = true
 ruff = "^0.7.3"
 pre-commit= "^4.0.1"
 
-[project.urls]
+[tool.project.urls]
 homepage = "https://github.com/DataWaveProject/nonlocal_gwfluxes"
 repository = "https://github.com/DataWaveProject/nonlocal_gwfluxes.git"
 issues = "https://github.com/DataWaveProject/nonlocal_gwfluxes/issues"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 description = "Datadriven models for predicting gravity wave fluxes in climate models."
 authors = [{ name = "amangupta2"}]
 readme = "README.md"
-license = "LICENSE"
+license = "MIT"
 keywords = ["non-local", "gravity waves"]
 dynamic = [ "dependencies" ]
 requires-python = ">=3.10.0"


### PR DESCRIPTION
fixes #35 

See issue #35 for description. Essentially, we need to update `pyproject.toml` if we want to use the latest versions of `poetry` (`>=v2.0.0`).